### PR TITLE
Include CloudFlare request ID in failure message

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--format progress
+--require spec_helper

--- a/lib/barsoom_utils/ping_health_check.rb
+++ b/lib/barsoom_utils/ping_health_check.rb
@@ -12,7 +12,10 @@ module BarsoomUtils
       response = ping_healthcheck
 
       if response.code != 200
-        raise "Bad response, CF-header: #{response.headers["CF-RAY"]}, response body: #{response.inspect}"
+        # "The presence of the cf-request-id header in the response confirms
+        # the request was proxied through Cloudflare"
+        #   https://support.cloudflare.com/hc/en-us/articles/203118044-Gathering-information-for-troubleshooting-sites
+        raise "Bad response, cf-request-id header: #{response.headers["cf-request-id"]}, response body: #{response.inspect}"
       else
         response
       end

--- a/spec/ping_health_check_spec.rb
+++ b/spec/ping_health_check_spec.rb
@@ -1,29 +1,36 @@
-require "spec_helper"
 require "barsoom_utils/ping_health_check"
 
-describe BarsoomUtils::PingHealthCheck, ".call" do
-  before do
+RSpec.describe BarsoomUtils::PingHealthCheck, ".call" do
+  around do |example|
     ENV["ENABLE_HEALTH_CHECKS"] = "true"
-  end
-
-  after do
+    example.run
     ENV["ENABLE_HEALTH_CHECKS"] = nil
   end
 
-  it "works" do
+  it "does nothing on a 200 OK response" do
     expect(HTTParty).to receive(:get).with("https://hchk.io/foo").and_return(double(:response, code: 200, headers: {}))
+
+    BarsoomUtils::PingHealthCheck.call("foo")
+  end
+
+  it "includes CloudFlare request ID header information in failure message" do
+    expect(HTTParty).to receive(:get).with("https://hchk.io/foo").and_return(double(:response, code: 503, headers: { "cf-request-id" => "023aa754ae0000517ab8829200000001"}))
+    expect(BarsoomUtils::ExceptionNotifier).to receive(:message).with(anything, /cf-request-id header: 023aa754ae0000517ab8829200000001/)
+
     BarsoomUtils::PingHealthCheck.call("foo")
   end
 
   it "silently reports an error to devs if it fails with a bad response code" do
     expect(HTTParty).to receive(:get).with("https://hchk.io/foo").and_return(double(:response, code: 404, headers: {}))
     expect(BarsoomUtils::ExceptionNotifier).to receive(:message).with(anything, /foo/)
+
     BarsoomUtils::PingHealthCheck.call("foo")
   end
 
   it "silently reports an error to devs if it fails with an exception" do
     expect(HTTParty).to receive(:get).with("https://hchk.io/foo").and_raise("fail")
     expect(BarsoomUtils::ExceptionNotifier).to receive(:message).with(anything, /foo/)
+
     BarsoomUtils::PingHealthCheck.call("foo")
   end
 end


### PR DESCRIPTION
This PR **changes the failure message** reported about CloudFlare identifiers, to **use the request ID** instead, which is not deprecated.

## Details

  - Read more about the new `cf-request-id` header: https://support.cloudflare.com/hc/en-us/articles/203118044-Gathering-information-for-troubleshooting-sites 
  - The `CF-RAY` header is deprecated, according to https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-Cloudflare-handle-HTTP-Request-headers-