### PR TITLE
Prefix describe with "RSpec."

### DIFF
--- a/spec/exception_notifier_spec.rb
+++ b/spec/exception_notifier_spec.rb
@@ -1,7 +1,6 @@
-require "spec_helper"
 require "barsoom_utils/exception_notifier"
 
-describe BarsoomUtils::ExceptionNotifier, ".notify" do
+RSpec.describe BarsoomUtils::ExceptionNotifier, ".notify" do
   before do
     stub_const("Honeybadger", double)
   end
@@ -28,7 +27,7 @@ describe BarsoomUtils::ExceptionNotifier, ".notify" do
   end
 end
 
-describe BarsoomUtils::ExceptionNotifier, ".message" do
+RSpec.describe BarsoomUtils::ExceptionNotifier, ".message" do
   before do
     stub_const("Honeybadger", double)
   end

--- a/spec/feature_toggle_spec.rb
+++ b/spec/feature_toggle_spec.rb
@@ -1,7 +1,6 @@
-require "spec_helper"
 require "barsoom_utils/feature_toggle"
 
-describe BarsoomUtils::FeatureToggle, ".turn_on" do
+RSpec.describe BarsoomUtils::FeatureToggle, ".turn_on" do
   it "sets the feature as not disabled" do
     redis = double
     expect(redis).to receive(:srem).with("disabled_feature_toggles", "foo")
@@ -9,7 +8,7 @@ describe BarsoomUtils::FeatureToggle, ".turn_on" do
   end
 end
 
-describe BarsoomUtils::FeatureToggle, ".turn_off" do
+RSpec.describe BarsoomUtils::FeatureToggle, ".turn_off" do
   it "sets the feature as disabled" do
     redis = double
     expect(redis).to receive(:sadd).with("disabled_feature_toggles", "foo")
@@ -17,7 +16,7 @@ describe BarsoomUtils::FeatureToggle, ".turn_off" do
   end
 end
 
-describe BarsoomUtils::FeatureToggle, ".on?, .off?" do
+RSpec.describe BarsoomUtils::FeatureToggle, ".on?, .off?" do
   let(:redis) { double(sismember: false) }
 
   context "by default" do

--- a/spec/spec/debug_helpers_spec.rb
+++ b/spec/spec/debug_helpers_spec.rb
@@ -1,7 +1,6 @@
-require "spec_helper"
 require "barsoom_utils/spec/debug_helpers"
 
-describe BarsoomUtils::Spec::DebugHelpers do
+RSpec.describe BarsoomUtils::Spec::DebugHelpers do
   before { module Rails; end }
 
   let(:page) { double(:page, source: "wow such html") }


### PR DESCRIPTION
This PR polishes the RSpec usage, to prepare to be able to do the same as in https://github.com/barsoom/traco/pull/42 

  - rely on `.rspec` for implicit `spec_helper` requires