### PR TITLE
fix: Style/FrozenStringLiteralComment RuboCop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in barsoom_utils.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)

--- a/barsoom_utils.gemspec
+++ b/barsoom_utils.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'barsoom_utils/version'

--- a/lib/barsoom_utils.rb
+++ b/lib/barsoom_utils.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "barsoom_utils/version"
 
 module BarsoomUtils

--- a/lib/barsoom_utils/exception_notifier.rb
+++ b/lib/barsoom_utils/exception_notifier.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Notify devs about an exception without necessarily
 # letting it appear to the user as a 500 error.
 

--- a/lib/barsoom_utils/feature_toggle.rb
+++ b/lib/barsoom_utils/feature_toggle.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "attr_extras"
 require "redis"
 

--- a/lib/barsoom_utils/ping_health_check.rb
+++ b/lib/barsoom_utils/ping_health_check.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "httparty"
 require "attr_extras"
 require "barsoom_utils/exception_notifier"

--- a/lib/barsoom_utils/spec/debug_helpers.rb
+++ b/lib/barsoom_utils/spec/debug_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "lolcat"
 
 module BarsoomUtils

--- a/lib/barsoom_utils/version.rb
+++ b/lib/barsoom_utils/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module BarsoomUtils
   VERSION = "0.1.0"
 end

--- a/spec/exception_notifier_spec.rb
+++ b/spec/exception_notifier_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "barsoom_utils/exception_notifier"
 
 RSpec.describe BarsoomUtils::ExceptionNotifier, ".notify" do

--- a/spec/feature_toggle_spec.rb
+++ b/spec/feature_toggle_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "barsoom_utils/feature_toggle"
 
 RSpec.describe BarsoomUtils::FeatureToggle, ".turn_on" do

--- a/spec/ping_health_check_spec.rb
+++ b/spec/ping_health_check_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "barsoom_utils/ping_health_check"
 
 RSpec.describe BarsoomUtils::PingHealthCheck, ".call" do

--- a/spec/spec/debug_helpers_spec.rb
+++ b/spec/spec/debug_helpers_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "barsoom_utils/spec/debug_helpers"
 
 RSpec.describe BarsoomUtils::Spec::DebugHelpers do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.configure do |config|
   config.disable_monkey_patching!
   config.order = "random"


### PR DESCRIPTION
This PR was created using this method:

```
rubocop -a --only Style/FrozenStringLiteralComment
bundle exec rake
```

Read more in [this old blog post by Pat](https://freelancing-gods.com/2017/07/27/an-introduction-to-frozen-string-literals.html).