### PR TITLE
Add Lint/RaiseException rule

### DIFF
--- a/shared_rubocop.yml
+++ b/shared_rubocop.yml
@@ -143,3 +143,6 @@ Style/StabbyLambdaParentheses:
 Layout/SpaceInLambdaLiteral:
   Enabled: true
   EnforcedStyle: require_no_space
+
+Lint/RaiseException:
+  Enabled: true


### PR DESCRIPTION
  - introduced in 0.81.0, https://github.com/rubocop-hq/rubocop/pull/7325

Short story:

```ruby
# bad
raise Exception, 'Error message here'
# good
raise StandardError, 'Error message here'
```