### PR TITLE
Introduce RuboCop rule Metrics/ParameterLists

### DIFF
--- a/shared_rubocop.yml
+++ b/shared_rubocop.yml
@@ -155,7 +155,7 @@ Lint/RaiseException:
 Style/RedundantBegin:
   Enabled: true
 
-# Warn about too many positional arguments in the parameter list when more than 5.
+# Warn about "too many positional arguments in the parameter list" when more than 5.
 # Warn about "too many positional arguments with optional values" when more than 3.
 Metrics/ParameterLists:
   Enabled: true

--- a/shared_rubocop.yml
+++ b/shared_rubocop.yml
@@ -154,3 +154,11 @@ Lint/RaiseException:
 # Skip redundant "begin"/"end" at the top level of method definitions or blocks.
 Style/RedundantBegin:
   Enabled: true
+
+# Warn about too many positional arguments in the parameter list when more than 5.
+# Warn about "too many positional arguments with optional values" when more than 3.
+Metrics/ParameterLists:
+  Enabled: true
+  CountKeywordArgs: false
+  Max: 5
+  MaxOptionalParameters: 3


### PR DESCRIPTION
Rule: [Metrics/ParameterLists](https://docs.rubocop.org/rubocop/cops_metrics.html#configurable-attributes-8)

This includes the default settings, for clarity.