### PR TITLE
RuboCop: Disable advertisement of new Extensions

### DIFF
--- a/shared_rubocop.yml
+++ b/shared_rubocop.yml
@@ -3,7 +3,7 @@
 AllCops:
   DisabledByDefault: true
   DisplayStyleGuide: true
-
+  SuggestExtensions: false
   Exclude:
     - db/schema.rb
     - vendor/**/*


### PR DESCRIPTION
RuboCop just began advertising for extensions, a bit "When you HTTParty, you must party hard!"-style.

After thinking of it, we can choose not to display this extra output, and then adopt as we go, instead of adding the suggested immediately.