### PR TITLE
feat: Enable lint rule Security/CompoundHash

### DIFF
--- a/shared_rubocop.yml
+++ b/shared_rubocop.yml
@@ -255,6 +255,9 @@ Style/HashSyntax:
 Security/IoMethods: # new in 1.22
   Enabled: true
 
+Security/CompoundHash: # new in 1.28
+  Enabled: true
+
 # https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecduplicatedassignment
 Gemspec/DuplicatedAssignment:
   Enabled: true


### PR DESCRIPTION
This PR adds a single new one:

    This cop checks for implementations of the hash method which combine values
    using custom logic instead of delegating to Array#hash.

https://docs.rubocop.org/rubocop/cops_security.html#securitycompoundhash