### PR TITLE
shared_rubocop_rails.yml: Add Rails/ActiveSupportAliases

### DIFF
--- a/shared_rubocop_rails.yml
+++ b/shared_rubocop_rails.yml
@@ -3,3 +3,7 @@
 # Allow e.g. `list.compact_blank` and disallow `list.reject(&:blank)`.
 Rails/CompactBlank:
   Enabled: true
+
+# Allow e.g. `String#end_with?` and disallow `String#ends_with?`.
+Rails/ActiveSupportAliases:
+  Enabled: true


### PR DESCRIPTION
See https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsactivesupportaliases for all details.