### PR TITLE
Enforce hash/kw arguments shorthand assignment

### DIFF
--- a/shared_rubocop.yml
+++ b/shared_rubocop.yml
@@ -286,7 +286,7 @@ Layout/ClassStructure:
 Style/HashSyntax:
   Enabled: true
   EnforcedStyle: ruby19
-  EnforcedShorthandSyntax: either_consistent # https://docs.rubocop.org/rubocop/cops_style.html#enforcedshorthandsyntax_-either_consistent-stylehashsyntax
+  EnforcedShorthandSyntax: always # https://docs.rubocop.org/rubocop/cops_style.html#enforcedshorthandsyntax_-always-stylehashsyntax
 
 # https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecduplicatedassignment
 Gemspec/DuplicatedAssignment:

--- a/shared_rubocop.yml
+++ b/shared_rubocop.yml
@@ -286,6 +286,7 @@ Layout/ClassStructure:
 Style/HashSyntax:
   Enabled: true
   EnforcedStyle: ruby19
+  EnforcedShorthandSyntax: either_consistent # https://docs.rubocop.org/rubocop/cops_style.html#enforcedshorthandsyntax_-either_consistent-stylehashsyntax
 
 # https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecduplicatedassignment
 Gemspec/DuplicatedAssignment:


### PR DESCRIPTION
We noticed this [here](https://github.com/barsoom/notify_bot/commit/b4662f51af753a5b1e67c8fd56361d1b612843f1?remit_anchorbuster=154445574#r154445574).

This added cop rule enforces the keyword/hash shorthand style across repos - more about the rule in the [official docs](https://docs.rubocop.org/rubocop/cops_style.html#enforcedshorthandsyntax_-always-stylehashsyntax).

❓ Several types of enforcing were possible - ~to maximize flexibility, I've chosen the one that enforces the style unless consistent within the file~ the one we want to keep is `always`, as it turns out it also supports mixed styles (the doc was not clear, see [Henrik's comment here](https://github.com/barsoom/barsoom_utils/pull/16#issuecomment-2765606971)). 
Any thoughts on this point?

```ruby
# with "EnforcedShorthandSyntax: always" enabled

# Bad
{foo: foo, bar: bar}

# Good
{foo:, bar:}
{foo:, bar: baz}  # still allowes to mix syntaxes, when not using the matching shorthand-assignment
```